### PR TITLE
Fix: minor definition issues

### DIFF
--- a/TS29122_MonitoringEvent.yaml
+++ b/TS29122_MonitoringEvent.yaml
@@ -425,7 +425,7 @@ components:
           $ref: '#/components/schemas/AssociationType'
         plmnIndication:
           type: boolean
-          description: If "monitoringType" is "ROAMING_STATUS", this parameter may be included to indicate the notification of UE's Serving PLMN ID. 	"true" indicates enabling of notification; "false" indicates disabling of notification. Default value is "false".
+          description: If "monitoringType" is "ROAMING_STATUS", this parameter may be included to indicate the notification of UE's Serving PLMN ID.     "true" indicates enabling of notification; "false" indicates disabling of notification. Default value is "false".
         locationArea:
           $ref: 'TS29122_CommonData.yaml#/components/schemas/LocationArea'
         locationArea5G:

--- a/TS29512_Npcf_SMPolicyControl.yaml
+++ b/TS29512_Npcf_SMPolicyControl.yaml
@@ -11,7 +11,7 @@ externalDocs:
   url: 'http://www.3gpp.org/ftp/Specs/archive/29_series/29.512/'
 security:
   - {}
-  - oAuth2Clientcredentials:
+  - oAuth2ClientCredentials:
     - npcf-smpolicycontrol
 servers:
   - url: '{apiRoot}/npcf-smpolicycontrol/v1'
@@ -455,7 +455,7 @@ paths:
           $ref: 'TS29571_CommonData.yaml#/components/responses/default'
 components:
   securitySchemes:
-    oAuth2Clientcredentials:
+    oAuth2ClientCredentials:
       type: oauth2
       flows: 
         clientCredentials: 

--- a/TS29562_Nhss_imsSDM.yaml
+++ b/TS29562_Nhss_imsSDM.yaml
@@ -2336,9 +2336,11 @@ components:
       type: array
       minItems: 1
       uniqueItems: true
-      properties:
-        requestedNode:
-          $ref: '#/components/schemas/RequestedNode'
+      items:
+        type: object
+        properties:
+          requestedNode:
+            $ref: '#/components/schemas/RequestedNode'
 
     PsLocation:
       type: object


### PR DESCRIPTION
Hi,

This PR aims to fix minor definition issues:

- https://github.com/jdegre/5GC_APIs/commit/46ce8ff09737a59d8967fc37607f06c87ffa55d8 replace YAML outlawed tab char with 4 spaces (see http://yaml.org/faq.html)
- https://github.com/jdegre/5GC_APIs/commit/0b081916b63d7b70dc4eab88e4d535ada54fc25b correct TS29562 `RequetedNodes` array definition, it was missing of the `items` property.
see https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-02#section-9.3.1.1:  ```
Omitting this keyword has the same assertion behavior as an empty schema.```
- https://github.com/jdegre/5GC_APIs/commit/721b078485a4aea664d0ac604f4d6c862f186019 correct a typo: `oAuth2Clientcredentials` -> `oAuth2ClientCredentials`

BR