### PR TITLE
Remove tab after vplmnQos

### DIFF
--- a/TS29512_Npcf_SMPolicyControl.yaml
+++ b/TS29512_Npcf_SMPolicyControl.yaml
@@ -1082,7 +1082,7 @@ components:
           description: Indicates the DN-AAA authorization profile index
         subsDefQos:
           $ref: 'TS29571_CommonData.yaml#/components/schemas/SubscribedDefaultQos'
-        vplmnQos:		
+        vplmnQos:
           $ref: 'TS29502_Nsmf_PDUSession.yaml#/components/schemas/VplmnQos'
         vplmnQosNotApp:
           type: boolean


### PR DESCRIPTION
Removing a tab character after vplmnQos. openapi-generator doesn't like this tab.