### PR TITLE
Fix RuleOperation enum extra spaces

### DIFF
--- a/TS29512_Npcf_SMPolicyControl.yaml
+++ b/TS29512_Npcf_SMPolicyControl.yaml
@@ -2222,8 +2222,8 @@ components:
           - CREATE_PCC_RULE
           - DELETE_PCC_RULE
           - MODIFY_PCC_RULE_AND_ADD_PACKET_FILTERS
-          - MODIFY_ PCC_RULE_AND_REPLACE_PACKET_FILTERS
-          - MODIFY_ PCC_RULE_AND_DELETE_PACKET_FILTERS
+          - MODIFY_PCC_RULE_AND_REPLACE_PACKET_FILTERS
+          - MODIFY_PCC_RULE_AND_DELETE_PACKET_FILTERS
           - MODIFY_PCC_RULE_WITHOUT_MODIFY_PACKET_FILTERS
       - type: string
         description: >
@@ -2235,8 +2235,8 @@ components:
         - CREATE_PCC_RULE: Indicates to create a new PCC rule to reserve the resource requested by the UE. 
         - DELETE_PCC_RULE: Indicates to delete a PCC rule corresponding to reserve the resource requested by the UE.
         - MODIFY_PCC_RULE_AND_ADD_PACKET_FILTERS: Indicates to modify the PCC rule by adding new packet filter(s).
-        - MODIFY_ PCC_RULE_AND_REPLACE_PACKET_FILTERS: Indicates to modify the PCC rule by replacing the existing packet filter(s).
-        - MODIFY_ PCC_RULE_AND_DELETE_PACKET_FILTERS: Indicates to modify the PCC rule by deleting the existing packet filter(s).
+        - MODIFY_PCC_RULE_AND_REPLACE_PACKET_FILTERS: Indicates to modify the PCC rule by replacing the existing packet filter(s).
+        - MODIFY_PCC_RULE_AND_DELETE_PACKET_FILTERS: Indicates to modify the PCC rule by deleting the existing packet filter(s).
         - MODIFY_PCC_RULE_WITHOUT_MODIFY_PACKET_FILTERS: Indicates to modify the PCC rule by modifying the QoS of the PCC rule.
     RedirectAddressType:
       anyOf:


### PR DESCRIPTION
Rel 17: RuleOperation enum values have extra spaces which break codes.