### PR TITLE
Change oneOf to anyOf in EndPoint Schema

### DIFF
--- a/TS29558_Eees_EASRegistration.yaml
+++ b/TS29558_Eees_EASRegistration.yaml
@@ -401,7 +401,7 @@ components:
           description: IPv6 addresses of the edge server.
         uri:
           $ref: 'TS29122_CommonData.yaml#/components/schemas/Uri'
-      oneOf:
+      anyOf:
         - required: [uri]
         - required: [fqdn]
         - required: [ipv4Addrs]


### PR DESCRIPTION
Hi,

We detected a -possible- incorrect validation of EndPoint schema in TS29558_Eees_EASRegistration.yaml. When you insert more than one field, the validation fails as the model can't validate against multiple models at the same time ([fqdn], [ipv6Addrs], [uri] and [ipv4Addrs]). According to 3GPP TS 29.558, at least one of the addressing parameters (fqdn, ipv4Addrs, ipv6Addrs, uri attributes) shall be included, but it could be more than one.

![225383651-42d9b2c0-6b8f-4c22-a16b-1861c121e14a](https://user-images.githubusercontent.com/116586749/226985659-98708b63-9d85-46e5-acd1-c8eb019d6238.png)

We suggest to use anyOf to pass the validation in case of more than one element is provided at the same time.

Best