### PR TITLE
Update TS28532_FileDataReportingMnS.yaml

### DIFF
--- a/TS28532_FileDataReportingMnS.yaml
+++ b/TS28532_FileDataReportingMnS.yaml
@@ -203,6 +203,8 @@ components:
           type: string
         fileDataType:
            $ref: '#/components/schemas/FileDataType'
+        jobId:
+          type: string
     NotifyFileReady:
       allOf:
         - $ref: 'TS28623_ComDefs.yaml#/components/schemas/NotificationHeader'


### PR DESCRIPTION
Missing JobId param for FileInfo schema. Check TS 28532

![imagen](https://github.com/jdegre/5GC_APIs/assets/136318650/ee41f287-24ed-4d28-8f79-54a159923ba2)
