### PR TITLE
Fix typo in TS29571_CommonData.yaml

### DIFF
--- a/TS29571_CommonData.yaml
+++ b/TS29571_CommonData.yaml
@@ -756,7 +756,7 @@ components:
             The reason string should identify the operation that failed using the operation's 
             array index to assist in correlation of the invalid parameter with the failed 
             operation, e.g. "Replacement value invalid for attribute (failed operation index= 4)".
-      description: indicates performed modivications.
+      description: Indicates performed modifications.
 
     HalTemplate:
       description: >


### PR DESCRIPTION
Going through `TS29571_CommonData.yaml`, I noticed a small typo ("modivications") for which this PR proposes a trivial fix :) I also took the freedom of adjusting the capitalization in that line.