### PR TITLE
minor typo fix subcription -> subscription

### DIFF
--- a/TS29508_Nsmf_EventExposure.yaml
+++ b/TS29508_Nsmf_EventExposure.yaml
@@ -27,7 +27,7 @@ security:
 paths:
   /subscriptions:
     post:
-      operationId: CreateIndividualSubcription
+      operationId: CreateIndividualSubscription
       summary: Create an individual subscription for event notifications from the SMF
       tags:
         - Subscriptions (Collection)
@@ -161,7 +161,7 @@ paths:
 
   /subscriptions/{subId}:
     get:
-      operationId: GetIndividualSubcription
+      operationId: GetIndividualSubscription
       summary: Read an individual subscription for event notifications from the SMF
       tags:
         - IndividualSubscription (Document)
@@ -204,7 +204,7 @@ paths:
         default:
           $ref: 'TS29571_CommonData.yaml#/components/responses/default'
     put:
-      operationId: ReplaceIndividualSubcription
+      operationId: ReplaceIndividualSubscription
       summary: Replace an individual subscription for event notifications from the SMF
       tags:
         - IndividualSubscription (Document)
@@ -259,7 +259,7 @@ paths:
         default:
           $ref: 'TS29571_CommonData.yaml#/components/responses/default'
     delete:
-      operationId: DeleteIndividualSubcription
+      operationId: DeleteIndividualSubscription
       summary: Delete an individual subscription for event notifications from the SMF
       tags:
         - IndividualSubscription (Document)


### PR DESCRIPTION
Hello,

I have noticed that there is a typo in couple of openapi specifications.

I am mindful that PR on github may not be the best place to contribute to the specification, so please feel free to close this issue and re-apply the patch through proper process.

Thank You for maintaining this repo.